### PR TITLE
Add createPluginRPC function for RPC calls

### DIFF
--- a/packages/client/src/application/hooks/plugins.tsx
+++ b/packages/client/src/application/hooks/plugins.tsx
@@ -5,12 +5,24 @@ import { selectCurrentPlugin } from '../reducers/plugins';
 import { trpc } from '../trpc';
 import useCurrentBot from './bots';
 
+/**
+ * Custom hook to retrieve the list of local plugins for the current bot.
+ *
+ * This hook uses the `useCurrentBot` hook to get the current bot's information
+ * and then fetches the local plugins associated with the bot's platform type.
+ *
+ * @returns An array of local plugins. If no plugins are found, an empty array is returned.
+ */
 export function usePlugins() {
   const bot = useCurrentBot();
   const { data: plugins } = trpc.getLocalPlugins.useQuery(bot.platformType);
   return plugins || [];
 }
 
+/**
+ * Custom hook to fetch and return the plugins associated with the current bot.
+ * @returns An array of plugins associated with the current bot. If no plugins are found, returns an empty array.
+ */
 export function useBotPlugins() {
   const bot = useCurrentBot();
   const { data: plugins } = trpc.getBotPlugins.useQuery(bot.id);
@@ -27,6 +39,9 @@ export function useCurrentPlugin() {
 
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
 
+/**
+ * @deprecated Use `createPluginRPC` instead.
+ */
 export function usePluginRPC<T extends Record<string, (params?: any) => any>>(
   name: keyof T,
   params?: Parameters<T[typeof name]>[0],
@@ -44,6 +59,9 @@ export function usePluginRPC<T extends Record<string, (params?: any) => any>>(
 }
 //   const bot = useCurrentBot();
 
+/**
+ * @deprecated Use `createPluginRPC` instead.
+ */
 export function usePluginRPCMutation<
   T extends Record<string, (params?: any) => any>,
 >(name: keyof T) {
@@ -60,5 +78,80 @@ export function usePluginRPCMutation<
       }) as UnwrapPromise<ReturnType<T[typeof name]>> | undefined;
     },
     isLoading: invoke.isLoading,
+  };
+}
+
+/**
+ * Creates a proxy object that provides `useQuery` and `useMutation` hooks for invoking plugin RPC methods.
+ *
+ * @template T - Type import of RPC from the server.
+ *
+ * @returns An object with keys as RPC method names and values as objects with:
+ * - `useQuery`: A hook to query data from the RPC method.
+ * - `useMutation`: A hook to mutate data using the RPC method.
+ *
+ * Example usage:
+ * ```typescript
+ * const pluginRPC = createPluginRPC<RPC>();
+ *
+ * // inside a React component
+ * function MyComponent() {
+ *  const data = pluginRPC.someMethod.useQuery(param1, param2);
+ *  const mutate = pluginRPC.someMethod.useMutation();
+ *  await mutate.mutateAsync(param);
+ * }
+ * ```
+ */
+export function createPluginRPC<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends Record<string, (params?: any) => any>,
+>() {
+  const bot = useCurrentBot();
+  const plugin = useCurrentPlugin();
+
+  return new Proxy(
+    {},
+    {
+      get(_, methodName: string) {
+        return {
+          useQuery: (...params: Parameters<T[typeof methodName]>) => {
+            const q = trpc.invokePluginRPCQuery.useQuery({
+              botId: bot.id,
+              pluginName: plugin.name,
+              name: methodName,
+              params,
+            });
+            return q.data;
+          },
+          useMutation: () => ({
+            mutateAsync: async (
+              params?: Parameters<T[typeof methodName]>[0],
+            ) => {
+              const response = await trpc.invokePluginRPCMutation
+                .useMutation()
+                .mutateAsync({
+                  botId: bot.id,
+                  pluginName: plugin.name,
+                  name: methodName,
+                  params,
+                });
+              return response;
+            },
+          }),
+        };
+      },
+    },
+  ) as {
+    [K in keyof T]: {
+      useQuery: (
+        ...args: Parameters<T[K]>
+      ) => UnwrapPromise<ReturnType<T[K]>> | undefined;
+      useMutation: () => {
+        mutateAsync: (
+          params?: Parameters<T[K]>[0],
+        ) => UnwrapPromise<ReturnType<T[K]>> | undefined;
+        isLoading: boolean;
+      };
+    };
   };
 }

--- a/plugins/telegram-post/src/client/page.tsx
+++ b/plugins/telegram-post/src/client/page.tsx
@@ -4,10 +4,9 @@ import {
   Link,
   SidebarItem,
   SidebarLayout,
+  createPluginRPC,
   toast,
   useCurrentBot,
-  usePluginRPC,
-  usePluginRPCMutation,
   useSearchParams,
 } from '@botmate/client';
 import { Button, Editor, PageLayout } from '@botmate/ui';
@@ -16,12 +15,14 @@ import { InlineKeyboardButton } from 'grammy/types';
 import type { RPC } from '../server';
 import KeyboardBuilder from './keyboard-builder';
 
+const rpc = createPluginRPC<RPC>();
+
 function Page() {
   const bot = useCurrentBot();
   const [searchParams] = useSearchParams();
 
-  const telegramChats = usePluginRPC<RPC>('getTelegramChats', 1);
-  const postMessage = usePluginRPCMutation<RPC>('postMessage');
+  const postMessage = rpc.postMessage.useMutation();
+  const telegramChats = rpc.getTelegramChats.useQuery(1);
 
   const chatId = searchParams.get('chat');
 


### PR DESCRIPTION
This pull request adds a new function called `createPluginRPC` that creates a proxy object providing `useQuery` and `useMutation` hooks for invoking plugin RPC methods. 